### PR TITLE
Datoms API, Pt. 1

### DIFF
--- a/resources/datoms-request-ex.json
+++ b/resources/datoms-request-ex.json
@@ -1,0 +1,4 @@
+{"index": ":aevt",
+ "components": [":measurement/uid"],
+ "offset": 10,
+ "limit": 100}

--- a/src/com/vendekagonlabs/datomic_query_service/db/query.clj
+++ b/src/com/vendekagonlabs/datomic_query_service/db/query.clj
@@ -3,7 +3,6 @@
             [clojure.java.io :as io]
             [io.pedestal.interceptor :as i]
             [org.parkerici.datomic.datalog.json-parser :as datalog-parser]
-            [com.vendekagonlabs.datomic-query-service.db :as db]
             [clojure.data.json :as json]))
 
 
@@ -46,7 +45,54 @@
     (when (seq inds)
       (first inds))))
 
+(defn ref-attr? [db attr-eid]
+  (= :db.type/ref
+     (-> (d/attribute db attr-eid)
+         (:value-type))))
+
+(defn ->ident [db eid]
+  (when-let [ident (:db/ident (d/entity db eid))]
+    ident))
+
+(defn maybe->ident [db attr-eid val]
+  (if-not (ref-attr? db attr-eid)
+    val
+    (or (->ident db val) val)))
+
+(defn hydrate-datom
+  "Given a Datomic Datom object, uses nth destructuring to pull it apart and transform
+  it into a map with :e :a :v and :tx keys, looking up idents when suitable for resolving
+  attribute names or ident enums."
+  [db [e a v tx]]
+  {:e e
+   :a (->ident db a)
+   :v (maybe->ident db a v)
+   :tx tx})
+
+(defn datoms->result-or-errors
+  [{:keys [db basis-t index components seek limit offset]}]
+  (let [offset* (or offset 0)
+        limit* (or limit 1000)
+        datoms-fn (if seek
+                    (partial d/seek-datoms db index)
+                    (partial d/datoms db index))
+        result (try
+                 (->> (apply datoms-fn components)
+                      (drop offset*)
+                      (take limit*)
+                      (mapv (partial hydrate-datom db)))
+                 (catch Exception e
+                   {:error (.getMessage e)
+                    :ex-info (ex-data e)}))]
+    (if (:error result)
+      result
+      {:result result
+       :basis-t basis-t})))
+
 (defn q->result-or-errors
+  "Returns the result of a query or -- in the case of errors --
+  a map which contains the error message and any reported ex-data
+  in the :error and :ex-info keys respectively."
   [{:keys [db basis-t query args timeout]}]
   (let [rule-index (rule-arg-index query)
         ;; note: arg parsing can throw
@@ -70,3 +116,17 @@
       q-result
       {:result  q-result
        :basis-t basis-t})))
+
+(comment
+  (require '[com.vendekagonlabs.datomic-query-service.db :as db])
+  (db/db-names)
+  (def dev-conn (db/connect-to "template-db"))
+  (def dev-db (d/db dev-conn))
+  (datoms->result-or-errors {:db dev-db
+                             :basis-t 1
+                             :index :aevt
+                             :components
+                             [:sample/subject]
+                             :seek true
+                             :limit 100
+                             :offset 100}))

--- a/test/com/vendekagonlabs/datomic_query_service/service_test.clj
+++ b/test/com/vendekagonlabs/datomic_query_service/service_test.clj
@@ -150,6 +150,18 @@
   ;; basis-t query still requires some manual inspection to setup and vet
   (reset-test-server)
 
+  (json/read-str (slurp (io/resource "datoms-request-ex.json"))
+                 :key-fn keyword)
+
+  ;; TODO: promote to test
+  (POST "/datoms/kapur-clean-repo"
+        :body (slurp (io/resource "datoms-request-ex.json"))
+        :headers
+        {"Content-Type" "application/json"
+         "Accept"       "application/json"
+         "Authorization"
+         (str "Bearer " (System/getenv "BEARER_TOKEN"))})
+
   (POST test-db-route
         :body (slurp (io/resource "basis-t-q.json"))
         :headers {"Content-Type"  "application/json"


### PR DESCRIPTION
This is a basic cut of Datoms API. The behavior is currently only REPL verified, but the pieces are now in comments in tests to support better/more comprehensive tests (see new issue #2).

Need quicker merge atm to enable downstream Python wrapping dev (generator iterator through datoms via the datoms API), which is why the chore work was moved out to a follow up.

This PR resolves #1.